### PR TITLE
Don't use mem::uninitialized

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ macro_rules! impl_elastic_array {
 		impl<T> $name<T> where T: Copy + Default {
 			pub fn new() -> $name<T> {
 				$name {
-					raw: $dummy::Arr([T::default();  $size]),
+					raw: $dummy::Arr([T::default(); $size]),
 					len: 0
 				}
 			}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ macro_rules! impl_elastic_array {
 		impl<T> $name<T> where T: Copy {
 			pub fn new() -> $name<T> {
 				$name {
-					raw: $dummy::Arr(unsafe { $crate::core_::mem::uninitialized() }),
+					raw: $dummy::Arr(unsafe { $crate::core_::mem::MaybeUninit::uninit().assume_init() }),
 					len: 0
 				}
 			}
@@ -176,7 +176,7 @@ macro_rules! impl_elastic_array {
 			}
 
 			pub fn clear(&mut self) {
-				self.raw = $dummy::Arr(unsafe { $crate::core_::mem::uninitialized() });
+				self.raw = $dummy::Arr(unsafe { $crate::core_::mem::MaybeUninit::uninit().assume_init() });
 				self.len = 0;
 			}
 


### PR DESCRIPTION
Don't use `mem::uninitialized()` to avoid UB and imminent deprecation. Adds a `Default` bound on the type parameter. 
The benchmark has a pretty weird regression for the `bench_vector` benchmark (it's weird because it [does not use `ElasticArray`](https://github.com/paritytech/elastic-array/blob/f6ec10c0f35d0f4403cb936a05e3b82bf9f92cf8/benches/elastic.rs#L59) at all) that I can't quite explain:

This PR:
```
test bench_elastic_array ... bench:       7,358 ns/iter (+/- 471)
test bench_vector        ... bench:       9,136 ns/iter (+/- 472)
```

Master:
```
test bench_elastic_array ... bench:       7,641 ns/iter (+/- 855)
test bench_vector        ... bench:       7,626 ns/iter (+/- 600)
```

(Many thanks to @niklasad1 for suggesting the right way here)